### PR TITLE
Add seperate steps for nightly build on ``dev`` branch and nightly build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,9 +3,9 @@ name: Build ZIP file
 
 on:
   push:
-    branches: [ main ]
   pull_request:
-    branches: [ main ]
+  schedule:
+    - cron: '0 0 * * 2'
 
 jobs:
   build:
@@ -20,11 +20,30 @@ jobs:
           echo "OSVER=$OSVER" >> $GITHUB_ENV
           echo The current version is $OSVER!
 
-      - name: ZIP files
+      - name: ZIP files for stable release
         run: zip "3DFox_OS_EUR_$OSVER.zip" ./ -r
+        if: ${{ github.ref_name == 'main' }}
 
-      - name: Upload ZIP file as an artifact
+      - name: Upload stable ZIP file as an artifact
         uses: actions/upload-artifact@v3
         with:
           name: 3DFox OS
           path: ./3DFox_OS_EUR_${{ env.OSVER }}.zip
+        if: ${{ github.ref_name == 'main' }}
+        
+      - name: ZIP files for nightly release
+        run: zip "3DFox_OS_EUR_nightly.zip" ./ -r
+        if: |
+          ${{ github.ref_name == 'dev' }} ||
+          ${{ github.event_name == 'pull_request' }} ||
+          ${{ github.event_name == 'schedule' }}
+
+      - name: Upload nightly ZIP file as an artifact
+        uses: actions/upload-artifact@v3
+        with:
+          name: 3DFox OS
+          path: ./3DFox_OS_EUR_nightly.zip
+        if: |
+          ${{ github.ref_name == 'dev' }} ||
+          ${{ github.event_name == 'pull_request' }} ||
+          ${{ github.event_name == 'schedule' }}


### PR DESCRIPTION
This adds seperate steps. The ``stable`` build will run when the push was made from the ``main`` branch. The ``nightly`` build will run when there is pushed from the ``dev`` branch, a pull request is made or when it is ran by the scheduled run on every Tuesday.